### PR TITLE
Don't rely on odd index

### DIFF
--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1417,6 +1417,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
     nucvec = {}
     table_ids = {}
     lib_names = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
+    default_libs = {}
 
     # skip the first token that is the material card identifier
     token_list = data_string.split()[1:]
@@ -1426,7 +1427,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
         if '=' in token:
             lib_name, lib_num = token.split('=')
             if lib_name in lib_names:
-                mat.metadata[lib_name.upper()] = lib_num
+                default_libs[lib_name.upper()] = lib_num
         else:
             nuc_info = token.split('.')
             zzzaaam = str(nucname.zzaaam(nucname.mcnp_to_id(nuc_info[0])))
@@ -1463,6 +1464,8 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
         mat = Material(nucvec=nucvec)
 
     mat.metadata['table_ids'] = table_ids
+    for lib_name, lib_num in default_libs.items():
+        mat.metadata[lib_name] = lib_num
     mat.metadata['mat_number'] = data_string.split()[0][1:]
 
     # collect metadata, if present

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1415,7 +1415,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
 
     # create dictionaries nucvec and table_ids
     nucvec = {}
-    table_ids = {'default': dict() }
+    table_ids = {'default': dict()}
     lib_names = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
 
     # skip the first token that is the material card identifier
@@ -1429,13 +1429,13 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
                 table_ids['default'][lib_name] = lib_num
         else:
             nuc_info = token.split('.')
-            zzzaaam =str(nucname.zzaaam(nucname.mcnp_to_id(nuc_info[0])))
+            zzzaaam = str(nucname.zzaaam(nucname.mcnp_to_id(nuc_info[0])))
             # this allows us to read nuclides that are repeated
             nuc_frac = token_list.pop(0)
             if zzzaaam in nucvec.keys():
                 nucvec[zzzaaam] += float(nuc_frac)
             else:
-                nucvec[zzzaaam] = float(nuc_frac)        
+                nucvec[zzzaaam] = float(nuc_frac)
             if len(nuc_info) > 1:
                 table_ids[str(zzzaaam)] = nuc_info[1]
 

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1415,7 +1415,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
 
     # create dictionaries nucvec and table_ids
     nucvec = {}
-    table_ids = {'default': None}
+    table_ids = {'default': dict() }
     lib_names = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
 
     # skip the first token that is the material card identifier

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1415,7 +1415,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
 
     # create dictionaries nucvec and table_ids
     nucvec = {}
-    table_ids = {'default': dict()}
+    table_ids = {}
     lib_names = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
 
     # skip the first token that is the material card identifier
@@ -1426,7 +1426,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
         if '=' in token:
             lib_name, lib_num = token.split('=')
             if lib_name in lib_names:
-                table_ids['default'][lib_name] = lib_num
+                mat.metadata[lib_name.upper()] = lib_num
         else:
             nuc_info = token.split('.')
             zzzaaam = str(nucname.zzaaam(nucname.mcnp_to_id(nuc_info[0])))

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1415,24 +1415,29 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
 
     # create dictionaries nucvec and table_ids
     nucvec = {}
-    table_ids = {}
-    lib_name = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
-    for i in range(1, len(data_string.split())):
-        # Reads default library indicators
-        token = data_string.split()[i].split('=')[0]
-        if token in lib_name:
-           table_ids[token] = data_string.split()[i].split('=')[1]             
-           continue
-        if i & 1 == 1:
-            zzzaaam = str(nucname.zzaaam(
-                nucname.mcnp_to_id(data_string.split()[i].split('.')[0])))
+    table_ids = {'default': None}
+    lib_names = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
+
+    # skip the first token that is the material card identifier
+    token_list = data_string.split()[1:]
+    while len(token_list) > 0:
+        token = token_list.pop(0)
+
+        if '=' in token:
+            lib_name, lib_num = token.split('=')
+            if lib_name in lib_names:
+                table_ids['default'][lib_name] = lib_num
+        else:
+            nuc_info = token.split('.')
+            zzzaaam =str(nucname.zzaaam(nucname.mcnp_to_id(nuc_info[0])))
             # this allows us to read nuclides that are repeated
+            nuc_frac = token_list.pop(0)
             if zzzaaam in nucvec.keys():
-                nucvec[zzzaaam] += float(data_string.split()[i+1])
+                nucvec[zzzaaam] += float(nuc_frac)
             else:
-                nucvec[zzzaaam] = float(data_string.split()[i+1])        
-            if len(data_string.split()[i].split('.')) > 1:
-                table_ids[str(zzzaaam)] = data_string.split()[i].split('.')[1]
+                nucvec[zzzaaam] = float(nuc_frac)        
+            if len(nuc_info) > 1:
+                table_ids[str(zzzaaam)] = nuc_info[1]
 
     # Check to see it material is definted my mass or atom fracs.
     # Do this by comparing the first non-zero fraction to the rest

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1416,7 +1416,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
     # create dictionaries nucvec and table_ids
     nucvec = {}
     table_ids = {}
-    lib_names = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
+    lib_names = ['NLIB', 'PLIB', 'HLIB', 'PNLIB', 'ELIB']
     default_libs = {}
 
     # skip the first token that is the material card identifier
@@ -1426,7 +1426,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
 
         if '=' in token:
             lib_name, lib_num = token.split('=')
-            if lib_name in lib_names:
+            if lib_name.upper() in lib_names:
                 default_libs[lib_name.upper()] = lib_num
         else:
             nuc_info = token.split('.')

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -903,7 +903,7 @@ std::string pyne::Material::phits(std::string frac_type, bool mult_den) {
   oss << " ]" << std::endl;
 
   // check for metadata
-  std::string keyworkds[6] = {"GAS", "ESTEP", "NLIB", "PLIB", "ELIB", "HLIB"};
+  std::string keyworkds[6] = {"GAS", "ESTEP", "NLIB", "PLIB", "PNLIB", "ELIB", "HLIB"};
   for (auto keyword : keyworkds){
     if (metadata.isMember(keyword)){
       oss << "     "<< keyword << "=" << metadata[keyword].asInt() << std::endl;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -903,7 +903,7 @@ std::string pyne::Material::phits(std::string frac_type, bool mult_den) {
   oss << " ]" << std::endl;
 
   // check for metadata
-  std::string keyworkds[6] = {"GAS", "ESTEP", "NLIB", "PLIB", "PNLIB", "ELIB", "HLIB"};
+  std::string keyworkds[7] = {"GAS", "ESTEP", "NLIB", "PLIB", "PNLIB", "ELIB", "HLIB"};
   for (auto keyword : keyworkds){
     if (metadata.isMember(keyword)){
       oss << "     "<< keyword << "=" << metadata[keyword].asInt() << std::endl;

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -513,7 +513,7 @@ def test_read_mcnp():
     expected_material_default_lib = Material({10000000: 0.037298334378601375, 
             60000000: 0.6666767493132514, 80000000: 0.29602491630814726}, 
             54.047494122635584, 1.1, 6.0, {"mat_number":"3",
-            "hlib":"42h","nlib":"60c","plib":"01p",
+            "HLIB":"42h","NLIB":"60c","PLIB":"01p",
             "table_ids":{}})
     expected_multimaterial = MultiMaterial({
         Material(

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -513,7 +513,8 @@ def test_read_mcnp():
     expected_material_default_lib = Material({10000000: 0.037298334378601375, 
             60000000: 0.6666767493132514, 80000000: 0.29602491630814726}, 
             54.047494122635584, 1.1, 6.0, {"mat_number":"3",
-            "table_ids":{"hlib":"42h","nlib":"60c","plib":"01p"}})
+            "hlib":"42h","nlib":"60c","plib":"01p",
+            "table_ids":{}})
     expected_multimaterial = MultiMaterial({
         Material(
             {10000000: 0.1118983878322976, 80000000: 0.8881016121677024},

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -512,9 +512,9 @@ def test_read_mcnp():
     expected_material.mass = -1.0  # to avoid reassignment to +1.0
     expected_material_default_lib = Material({10000000: 0.037298334378601375, 
             60000000: 0.6666767493132514, 80000000: 0.29602491630814726}, 
-            54.047494122635584, 1.1, 6.0, 
+            54.047494122635584, 1.1, 6.0,
             {"mat_number": "3",
-             "HLIB":  "42h", "NLIB":"60c", "PLIB": "01p",
+             "HLIB": "42h", "NLIB": "60c", "PLIB": "01p",
              "table_ids": {}})
     expected_multimaterial = MultiMaterial({
         Material(

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -512,9 +512,9 @@ def test_read_mcnp():
     expected_material.mass = -1.0  # to avoid reassignment to +1.0
     expected_material_default_lib = Material({10000000: 0.037298334378601375, 
             60000000: 0.6666767493132514, 80000000: 0.29602491630814726}, 
-            54.047494122635584, 1.1, 6.0, {"mat_number":"3",
-            "HLIB":"42h","NLIB":"60c","PLIB":"01p",
-            "table_ids":{}})
+            54.047494122635584, 1.1, 6.0, {"mat_number": "3",
+                "HLIB":  "42h", "NLIB":"60c", "PLIB": "01p",
+                "table_ids": {}})
     expected_multimaterial = MultiMaterial({
         Material(
             {10000000: 0.1118983878322976, 80000000: 0.8881016121677024},

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -512,9 +512,10 @@ def test_read_mcnp():
     expected_material.mass = -1.0  # to avoid reassignment to +1.0
     expected_material_default_lib = Material({10000000: 0.037298334378601375, 
             60000000: 0.6666767493132514, 80000000: 0.29602491630814726}, 
-            54.047494122635584, 1.1, 6.0, {"mat_number": "3",
-                "HLIB":  "42h", "NLIB":"60c", "PLIB": "01p",
-                "table_ids": {}})
+            54.047494122635584, 1.1, 6.0, 
+            {"mat_number": "3",
+             "HLIB":  "42h", "NLIB":"60c", "PLIB": "01p",
+             "table_ids": {}})
     expected_multimaterial = MultiMaterial({
         Material(
             {10000000: 0.1118983878322976, 80000000: 0.8881016121677024},


### PR DESCRIPTION
This suggestion makes a number of changes.  In general, it is a little
more verbose with variables for long term clarity.  Specifically, it no
longer relies on the counting the entries in the token_list and acting
on the odd ones defined by (i & 1 == 1).  Instead, it pops tokens off
the list and acts on them according to their characteristics.  Some
passes through the while-loop only consume a single token from
the list while others consume 2 tokens from the list.